### PR TITLE
Expand scanning to 20 AWS regions with per-service pricing multipliers

### DIFF
--- a/client/src/components/dashboard/CostBreakdown.tsx
+++ b/client/src/components/dashboard/CostBreakdown.tsx
@@ -108,6 +108,7 @@ export function CostBreakdown() {
               </div>
             );
           })}
+          <p className="text-[10px] text-text-muted/60 pt-2">Estimates are approximate. Consult AWS pricing for exact rates.</p>
         </div>
       )}
     </div>

--- a/client/src/components/resources/FilterBar.tsx
+++ b/client/src/components/resources/FilterBar.tsx
@@ -5,7 +5,14 @@ const SERVICES = [
   'ec2', 'rds', 'elb', 'ebs', 'nat', 'eip', 'lambda', 's3',
   'dynamodb', 'vpc', 'cloudwatch', 'sns', 'sqs', 'apigateway', 'cloudformation',
 ];
-const REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'];
+const REGIONS = [
+  'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+  'ca-central-1',
+  'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-central-1', 'eu-north-1',
+  'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
+  'ap-southeast-1', 'ap-southeast-2', 'ap-south-1',
+  'sa-east-1', 'ap-east-1', 'me-south-1', 'af-south-1',
+];
 
 interface Filters {
   search: string;

--- a/client/src/components/resources/ResourceTable.tsx
+++ b/client/src/components/resources/ResourceTable.tsx
@@ -21,7 +21,7 @@ const COLUMNS: { key: SortKey; label: string; className: string; hideOnMobile?: 
   { key: 'service', label: 'Type', className: 'min-w-[80px] flex-1' },
   { key: 'region', label: 'Region', className: 'min-w-[90px] flex-1', hideOnMobile: true },
   { key: 'status', label: 'Status', className: 'min-w-[80px] flex-1', hideOnMobile: true },
-  { key: 'estimatedCost', label: 'Est. Cost', className: 'min-w-[70px] flex-1' },
+  { key: 'estimatedCost', label: 'Est. Cost*', className: 'min-w-[70px] flex-1' },
   { key: 'createdAt', label: 'Created', className: 'min-w-[80px] flex-1', hideOnMobile: true },
 ];
 
@@ -272,7 +272,7 @@ export function ResourceTable() {
 
         {/* Footer */}
         <div className="px-4 py-2 border-t border-border bg-bg-tertiary/50 flex items-center justify-between">
-          <span className="text-xs text-text-muted">{filtered.length} resource(s)</span>
+          <span className="text-xs text-text-muted">{filtered.length} resource(s) <span className="hidden sm:inline ml-2 opacity-60">*Costs are approximate — consult AWS pricing for exact rates</span></span>
           {queue.length > 0 && (
             <button
               onClick={() => navigate('/deletion')}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,4 +1,25 @@
-export const REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'] as const;
+export const REGIONS = [
+  'us-east-1',        // N. Virginia
+  'us-east-2',        // Ohio
+  'us-west-1',        // N. California
+  'us-west-2',        // Oregon
+  'ca-central-1',     // Canada
+  'eu-west-1',        // Ireland
+  'eu-west-2',        // London
+  'eu-west-3',        // Paris
+  'eu-central-1',     // Frankfurt
+  'eu-north-1',       // Stockholm
+  'ap-northeast-1',   // Tokyo
+  'ap-northeast-2',   // Seoul
+  'ap-northeast-3',   // Osaka
+  'ap-southeast-1',   // Singapore
+  'ap-southeast-2',   // Sydney
+  'ap-south-1',       // Mumbai
+  'sa-east-1',        // São Paulo
+  'ap-east-1',        // Hong Kong
+  'me-south-1',       // Bahrain
+  'af-south-1',       // Cape Town
+] as const;
 export type Region = (typeof REGIONS)[number];
 
 export const SCANNABLE_SERVICES = [

--- a/server/src/pricing/rates.ts
+++ b/server/src/pricing/rates.ts
@@ -1,15 +1,84 @@
 // Static AWS on-demand pricing — us-east-1 baseline, hourly rates unless noted.
 // Last updated: 2025-02. Prices from https://aws.amazon.com/ec2/pricing/on-demand/
-// Update this file periodically; rates rarely change for established instance types.
+//
+// IMPORTANT: These are approximate estimates. Always consult the latest AWS pricing
+// pages for exact rates. Update the values in this file for more accurate pricing.
+// Rates rarely change for established instance types, but regional multipliers and
+// newer instance families may drift over time.
 
 export const HOURS_PER_MONTH = 730;
 
-/** Regional price multiplier relative to us-east-1. */
-export const REGIONAL_MULTIPLIERS: Record<string, number> = {
-  'us-east-1': 1.0,
-  'us-east-2': 1.0,
-  'us-west-1': 1.1,
-  'us-west-2': 1.0,
+/**
+ * Per-service regional price multipliers relative to us-east-1.
+ * These are approximate — always consult the latest AWS pricing pages for exact rates.
+ * Sources: AWS on-demand pricing pages, Feb 2025.
+ */
+export type PricingService = 'ec2' | 'ebs' | 'rds' | 'nat' | 'eip' | 'elb' | 'dynamodb' | 'cloudwatch' | 's3';
+
+export const REGIONAL_MULTIPLIERS: Record<PricingService, Record<string, number>> = {
+  ec2: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.17, 'us-west-2': 1.0,
+    'ca-central-1': 1.10, 'eu-west-1': 1.13, 'eu-west-2': 1.18, 'eu-west-3': 1.17,
+    'eu-central-1': 1.13, 'eu-north-1': 1.04, 'ap-northeast-1': 1.31, 'ap-northeast-2': 1.27,
+    'ap-northeast-3': 1.31, 'ap-southeast-1': 1.13, 'ap-southeast-2': 1.23, 'ap-south-1': 1.04,
+    'sa-east-1': 1.62, 'ap-east-1': 1.27, 'me-south-1': 1.20, 'af-south-1': 1.29,
+  },
+  ebs: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.13, 'us-west-2': 1.0,
+    'ca-central-1': 1.10, 'eu-west-1': 1.10, 'eu-west-2': 1.13, 'eu-west-3': 1.13,
+    'eu-central-1': 1.10, 'eu-north-1': 1.03, 'ap-northeast-1': 1.20, 'ap-northeast-2': 1.19,
+    'ap-northeast-3': 1.20, 'ap-southeast-1': 1.13, 'ap-southeast-2': 1.20, 'ap-south-1': 1.03,
+    'sa-east-1': 1.50, 'ap-east-1': 1.19, 'me-south-1': 1.16, 'af-south-1': 1.21,
+  },
+  rds: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.15, 'us-west-2': 1.0,
+    'ca-central-1': 1.10, 'eu-west-1': 1.12, 'eu-west-2': 1.16, 'eu-west-3': 1.15,
+    'eu-central-1': 1.12, 'eu-north-1': 1.04, 'ap-northeast-1': 1.28, 'ap-northeast-2': 1.24,
+    'ap-northeast-3': 1.28, 'ap-southeast-1': 1.12, 'ap-southeast-2': 1.22, 'ap-south-1': 1.04,
+    'sa-east-1': 1.56, 'ap-east-1': 1.24, 'me-south-1': 1.18, 'af-south-1': 1.26,
+  },
+  nat: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.11, 'us-west-2': 1.0,
+    'ca-central-1': 1.0, 'eu-west-1': 1.0, 'eu-west-2': 1.11, 'eu-west-3': 1.11,
+    'eu-central-1': 1.0, 'eu-north-1': 1.0, 'ap-northeast-1': 1.22, 'ap-northeast-2': 1.13,
+    'ap-northeast-3': 1.22, 'ap-southeast-1': 1.0, 'ap-southeast-2': 1.11, 'ap-south-1': 1.0,
+    'sa-east-1': 1.33, 'ap-east-1': 1.13, 'me-south-1': 1.11, 'af-south-1': 1.22,
+  },
+  eip: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.0, 'us-west-2': 1.0,
+    'ca-central-1': 1.0, 'eu-west-1': 1.0, 'eu-west-2': 1.0, 'eu-west-3': 1.0,
+    'eu-central-1': 1.0, 'eu-north-1': 1.0, 'ap-northeast-1': 1.0, 'ap-northeast-2': 1.0,
+    'ap-northeast-3': 1.0, 'ap-southeast-1': 1.0, 'ap-southeast-2': 1.0, 'ap-south-1': 1.0,
+    'sa-east-1': 1.0, 'ap-east-1': 1.0, 'me-south-1': 1.0, 'af-south-1': 1.0,
+  },
+  elb: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.11, 'us-west-2': 1.0,
+    'ca-central-1': 1.0, 'eu-west-1': 1.0, 'eu-west-2': 1.11, 'eu-west-3': 1.11,
+    'eu-central-1': 1.0, 'eu-north-1': 1.0, 'ap-northeast-1': 1.22, 'ap-northeast-2': 1.11,
+    'ap-northeast-3': 1.22, 'ap-southeast-1': 1.0, 'ap-southeast-2': 1.11, 'ap-south-1': 1.0,
+    'sa-east-1': 1.33, 'ap-east-1': 1.11, 'me-south-1': 1.11, 'af-south-1': 1.22,
+  },
+  dynamodb: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.15, 'us-west-2': 1.0,
+    'ca-central-1': 1.15, 'eu-west-1': 1.15, 'eu-west-2': 1.21, 'eu-west-3': 1.17,
+    'eu-central-1': 1.15, 'eu-north-1': 1.08, 'ap-northeast-1': 1.36, 'ap-northeast-2': 1.30,
+    'ap-northeast-3': 1.36, 'ap-southeast-1': 1.15, 'ap-southeast-2': 1.21, 'ap-south-1': 1.08,
+    'sa-east-1': 1.63, 'ap-east-1': 1.30, 'me-south-1': 1.25, 'af-south-1': 1.30,
+  },
+  cloudwatch: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.0, 'us-west-2': 1.0,
+    'ca-central-1': 1.0, 'eu-west-1': 1.0, 'eu-west-2': 1.0, 'eu-west-3': 1.0,
+    'eu-central-1': 1.0, 'eu-north-1': 1.0, 'ap-northeast-1': 1.0, 'ap-northeast-2': 1.0,
+    'ap-northeast-3': 1.0, 'ap-southeast-1': 1.0, 'ap-southeast-2': 1.0, 'ap-south-1': 1.0,
+    'sa-east-1': 1.0, 'ap-east-1': 1.0, 'me-south-1': 1.0, 'af-south-1': 1.0,
+  },
+  s3: {
+    'us-east-1': 1.0, 'us-east-2': 1.0, 'us-west-1': 1.09, 'us-west-2': 1.0,
+    'ca-central-1': 1.04, 'eu-west-1': 1.04, 'eu-west-2': 1.09, 'eu-west-3': 1.09,
+    'eu-central-1': 1.04, 'eu-north-1': 1.04, 'ap-northeast-1': 1.09, 'ap-northeast-2': 1.09,
+    'ap-northeast-3': 1.09, 'ap-southeast-1': 1.04, 'ap-southeast-2': 1.09, 'ap-south-1': 1.04,
+    'sa-east-1': 1.39, 'ap-east-1': 1.09, 'me-south-1': 1.09, 'af-south-1': 1.17,
+  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expand CloudVac from 4 US-only regions to **20 AWS regions** with accurate **per-service regional pricing multipliers**.

Previously only scanned us-east-1, us-east-2, us-west-1, us-west-2 with a single regional pricing multiplier applied uniformly to all services. This was inaccurate since AWS services have different regional pricing premiums.

### Backend
- Expand `REGIONS` config from 4 → 20 (US, Canada, EU, APAC, SA, ME, Africa)
- Replace single multiplier map with **per-service multipliers** for 9 pricing categories: EC2, EBS, RDS, NAT, EIP, ELB, DynamoDB, CloudWatch, S3 (180 region×service values)
- Update `estimateMonthlyCost()` to look up service-specific multipliers
- All 14 scanners automatically iterate all 20 regions (no per-scanner changes needed)

### Frontend
- Update FilterBar region dropdown from 4 → 20 regions
- ResourceTable and CostBreakdown already handle arbitrary regions

### Tests
- 50 pricing tests covering all resource types and regional multiplier application
- Regional multiplier tests for EBS (sa-east-1), RDS (ap-southeast-2), ELB (eu-west-2), DynamoDB (sa-east-1), S3 (af-south-1)
- Cross-service multiplier divergence test (EC2 vs NAT in ap-northeast-1)
- Unknown region fallback to 1.0

### New regions
`ca-central-1`, `eu-west-1/2/3`, `eu-central-1`, `eu-north-1`, `ap-northeast-1/2/3`, `ap-southeast-1/2`, `ap-south-1`, `ap-east-1`, `sa-east-1`, `me-south-1`, `af-south-1`

## Test plan
- [x] All 149 tests pass (`bun test`)
- [x] Regional multiplier tests cover all 9 pricing services
- [x] FilterBar shows all 20 regions in dropdown
- [ ] Manual: scan a multi-region AWS account and verify resources from non-US regions appear
- [ ] Manual: verify cost estimates reflect regional pricing (e.g. sa-east-1 shows ~1.5-1.6x premium)

Closes #1