### PR TITLE
feat(ui): Add AWS profile label and mode tooltips to header 

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useCallback, useRef } from "react";
-import { Scan, ChevronDown, ShieldCheck, ShieldOff } from "lucide-react";
-import { useProfileStore } from "../../stores/profile-store";
-import { useScanStore } from "../../stores/scan-store";
-import { useDeletionStore } from "../../stores/deletion-store";
-import { useBucketStore } from "../../stores/bucket-store";
-import { useCostStore } from "../../stores/cost-store";
-import { useScan } from "../../hooks/use-scan";
-import { Spinner } from "../shared/Spinner";
-import { ProgressBar } from "../shared/ProgressBar";
+import { useEffect, useCallback, useRef } from 'react';
+import { Scan, ChevronDown, ShieldCheck, ShieldOff } from 'lucide-react';
+import { useProfileStore } from '../../stores/profile-store';
+import { useScanStore } from '../../stores/scan-store';
+import { useDeletionStore } from '../../stores/deletion-store';
+import { useBucketStore } from '../../stores/bucket-store';
+import { useCostStore } from '../../stores/cost-store';
+import { useScan } from '../../hooks/use-scan';
+import { Spinner } from '../shared/Spinner';
+import { ProgressBar } from '../shared/ProgressBar';
 
 export function Header() {
   const profiles = useProfileStore((s) => s.profiles);
@@ -31,7 +31,7 @@ export function Header() {
 
   // When profile changes, load cached resources + bucket stats + cost estimates instantly
   useEffect(() => {
-    if (selectedProfile && scanStatus !== "scanning") {
+    if (selectedProfile && scanStatus !== 'scanning') {
       clearQueue();
       loadCachedResources(selectedProfile);
       loadCachedStats(selectedProfile);
@@ -42,11 +42,7 @@ export function Header() {
   // When scan completes, refresh cost estimates (new resources may have been found)
   const prevScanStatus = useRef(scanStatus);
   useEffect(() => {
-    if (
-      prevScanStatus.current === "scanning" &&
-      scanStatus === "complete" &&
-      selectedProfile
-    ) {
+    if (prevScanStatus.current === 'scanning' && scanStatus === 'complete' && selectedProfile) {
       // Small delay so the resources fetch can finish first
       const timer = setTimeout(() => fetchEstimates(selectedProfile), 500);
       return () => clearTimeout(timer);
@@ -54,15 +50,12 @@ export function Header() {
     prevScanStatus.current = scanStatus;
   }, [scanStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleProfileChange = useCallback(
-    (name: string) => {
-      selectProfile(name);
-    },
-    [selectProfile],
-  );
+  const handleProfileChange = useCallback((name: string) => {
+    selectProfile(name);
+  }, [selectProfile]);
 
   const lastScanLabel = scannedAt
-    ? `Last scan: ${new Date(scannedAt + "Z").toLocaleString()}`
+    ? `Last scan: ${new Date(scannedAt + 'Z').toLocaleString()}`
     : null;
 
   return (
@@ -70,12 +63,10 @@ export function Header() {
       <div className="flex items-center gap-2 sm:gap-4 min-w-0 pl-10 md:pl-0">
         {/* Profile selector */}
         <div className="flex items-center gap-2 shrink-0">
-          <span className="text-sm text-text-muted hidden lg:inline">
-            AWS Profile:
-          </span>
+          <span className="text-sm text-text-muted hidden lg:inline">AWS Profile:</span>
           <div className="relative">
             <select
-              value={selectedProfile ?? ""}
+              value={selectedProfile ?? ''}
               onChange={(e) => handleProfileChange(e.target.value)}
               className="appearance-none bg-bg-tertiary border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-primary focus:outline-none focus:border-accent cursor-pointer max-w-[140px] sm:max-w-none"
             >
@@ -85,34 +76,25 @@ export function Header() {
                 </option>
               ))}
             </select>
-            <ChevronDown
-              size={14}
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none"
-            />
+            <ChevronDown size={14} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none" />
           </div>
         </div>
 
         {/* Scan progress */}
-        {scanStatus === "scanning" && (
+        {scanStatus === 'scanning' && (
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             <Spinner size="sm" />
-            <span className="text-sm text-text-secondary hidden sm:inline">
-              Scanning...
-            </span>
+            <span className="text-sm text-text-secondary hidden sm:inline">Scanning...</span>
             <div className="w-20 sm:w-32">
               <ProgressBar value={progress} />
             </div>
-            <span className="text-xs text-text-muted">
-              {Math.round(progress * 100)}%
-            </span>
+            <span className="text-xs text-text-muted">{Math.round(progress * 100)}%</span>
           </div>
         )}
 
         {/* Last scan timestamp — hide on small screens */}
-        {lastScanLabel && scanStatus !== "scanning" && (
-          <span className="text-xs text-text-muted hidden lg:inline">
-            {lastScanLabel}
-          </span>
+        {lastScanLabel && scanStatus !== 'scanning' && (
+          <span className="text-xs text-text-muted hidden lg:inline">{lastScanLabel}</span>
         )}
       </div>
 
@@ -120,33 +102,25 @@ export function Header() {
         {/* Dry-run toggle */}
         <button
           onClick={toggleDryRun}
-          title={
-            dryRun
-              ? "Preview deletions without actually removing resources"
-              : "Deletions will permanently remove AWS resources"
-          }
+          title={dryRun ? 'Dry Run: Preview deletions without actually removing resources' : 'LIVE Mode: Deletions will permanently remove AWS resources'}
           className={`flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
             dryRun
-              ? "bg-success/10 text-success border-success/30 hover:bg-success/20"
-              : "bg-danger/10 text-danger border-danger/30 hover:bg-danger/20"
+              ? 'bg-success/10 text-success border-success/30 hover:bg-success/20'
+              : 'bg-danger/10 text-danger border-danger/30 hover:bg-danger/20'
           }`}
         >
           {dryRun ? <ShieldCheck size={15} /> : <ShieldOff size={15} />}
-          <span className="hidden sm:inline">
-            {dryRun ? "Dry Run" : "LIVE"}
-          </span>
+          <span className="hidden sm:inline">{dryRun ? 'Dry Run' : 'LIVE'}</span>
         </button>
 
         {/* Scan button */}
         <button
           onClick={startScan}
-          disabled={!selectedProfile || scanStatus === "scanning"}
+          disabled={!selectedProfile || scanStatus === 'scanning'}
           className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
           <Scan size={16} />
-          <span className="hidden sm:inline">
-            {scanStatus === "scanning" ? "Scanning..." : "Scan Account"}
-          </span>
+          <span className="hidden sm:inline">{scanStatus === 'scanning' ? 'Scanning...' : 'Scan Account'}</span>
           <span className="sm:hidden">Scan</span>
         </button>
       </div>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useCallback, useRef } from 'react';
-import { Scan, ChevronDown, ShieldCheck, ShieldOff } from 'lucide-react';
-import { useProfileStore } from '../../stores/profile-store';
-import { useScanStore } from '../../stores/scan-store';
-import { useDeletionStore } from '../../stores/deletion-store';
-import { useBucketStore } from '../../stores/bucket-store';
-import { useCostStore } from '../../stores/cost-store';
-import { useScan } from '../../hooks/use-scan';
-import { Spinner } from '../shared/Spinner';
-import { ProgressBar } from '../shared/ProgressBar';
+import { useEffect, useCallback, useRef } from "react";
+import { Scan, ChevronDown, ShieldCheck, ShieldOff } from "lucide-react";
+import { useProfileStore } from "../../stores/profile-store";
+import { useScanStore } from "../../stores/scan-store";
+import { useDeletionStore } from "../../stores/deletion-store";
+import { useBucketStore } from "../../stores/bucket-store";
+import { useCostStore } from "../../stores/cost-store";
+import { useScan } from "../../hooks/use-scan";
+import { Spinner } from "../shared/Spinner";
+import { ProgressBar } from "../shared/ProgressBar";
 
 export function Header() {
   const profiles = useProfileStore((s) => s.profiles);
@@ -31,7 +31,7 @@ export function Header() {
 
   // When profile changes, load cached resources + bucket stats + cost estimates instantly
   useEffect(() => {
-    if (selectedProfile && scanStatus !== 'scanning') {
+    if (selectedProfile && scanStatus !== "scanning") {
       clearQueue();
       loadCachedResources(selectedProfile);
       loadCachedStats(selectedProfile);
@@ -42,7 +42,11 @@ export function Header() {
   // When scan completes, refresh cost estimates (new resources may have been found)
   const prevScanStatus = useRef(scanStatus);
   useEffect(() => {
-    if (prevScanStatus.current === 'scanning' && scanStatus === 'complete' && selectedProfile) {
+    if (
+      prevScanStatus.current === "scanning" &&
+      scanStatus === "complete" &&
+      selectedProfile
+    ) {
       // Small delay so the resources fetch can finish first
       const timer = setTimeout(() => fetchEstimates(selectedProfile), 500);
       return () => clearTimeout(timer);
@@ -50,12 +54,15 @@ export function Header() {
     prevScanStatus.current = scanStatus;
   }, [scanStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleProfileChange = useCallback((name: string) => {
-    selectProfile(name);
-  }, [selectProfile]);
+  const handleProfileChange = useCallback(
+    (name: string) => {
+      selectProfile(name);
+    },
+    [selectProfile],
+  );
 
   const lastScanLabel = scannedAt
-    ? `Last scan: ${new Date(scannedAt + 'Z').toLocaleString()}`
+    ? `Last scan: ${new Date(scannedAt + "Z").toLocaleString()}`
     : null;
 
   return (
@@ -63,10 +70,12 @@ export function Header() {
       <div className="flex items-center gap-2 sm:gap-4 min-w-0 pl-10 md:pl-0">
         {/* Profile selector */}
         <div className="flex items-center gap-2 shrink-0">
-          <span className="text-sm text-text-muted hidden lg:inline">AWS Profile:</span>
+          <span className="text-sm text-text-muted hidden lg:inline">
+            AWS Profile:
+          </span>
           <div className="relative">
             <select
-              value={selectedProfile ?? ''}
+              value={selectedProfile ?? ""}
               onChange={(e) => handleProfileChange(e.target.value)}
               className="appearance-none bg-bg-tertiary border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-primary focus:outline-none focus:border-accent cursor-pointer max-w-[140px] sm:max-w-none"
             >
@@ -76,25 +85,34 @@ export function Header() {
                 </option>
               ))}
             </select>
-            <ChevronDown size={14} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none" />
+            <ChevronDown
+              size={14}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none"
+            />
           </div>
         </div>
 
         {/* Scan progress */}
-        {scanStatus === 'scanning' && (
+        {scanStatus === "scanning" && (
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             <Spinner size="sm" />
-            <span className="text-sm text-text-secondary hidden sm:inline">Scanning...</span>
+            <span className="text-sm text-text-secondary hidden sm:inline">
+              Scanning...
+            </span>
             <div className="w-20 sm:w-32">
               <ProgressBar value={progress} />
             </div>
-            <span className="text-xs text-text-muted">{Math.round(progress * 100)}%</span>
+            <span className="text-xs text-text-muted">
+              {Math.round(progress * 100)}%
+            </span>
           </div>
         )}
 
         {/* Last scan timestamp — hide on small screens */}
-        {lastScanLabel && scanStatus !== 'scanning' && (
-          <span className="text-xs text-text-muted hidden lg:inline">{lastScanLabel}</span>
+        {lastScanLabel && scanStatus !== "scanning" && (
+          <span className="text-xs text-text-muted hidden lg:inline">
+            {lastScanLabel}
+          </span>
         )}
       </div>
 
@@ -104,27 +122,31 @@ export function Header() {
           onClick={toggleDryRun}
           title={
             dryRun
-              ? 'Dry Run: Preview deletions without actually removing resources'
-              : 'LIVE Mode: Deletions will permanently remove AWS resources'
+              ? "Preview deletions without actually removing resources"
+              : "Deletions will permanently remove AWS resources"
           }
           className={`flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
             dryRun
-              ? 'bg-success/10 text-success border-success/30 hover:bg-success/20'
-              : 'bg-danger/10 text-danger border-danger/30 hover:bg-danger/20'
+              ? "bg-success/10 text-success border-success/30 hover:bg-success/20"
+              : "bg-danger/10 text-danger border-danger/30 hover:bg-danger/20"
           }`}
         >
           {dryRun ? <ShieldCheck size={15} /> : <ShieldOff size={15} />}
-          <span className="hidden sm:inline">{dryRun ? 'Dry Run' : 'LIVE'}</span>
+          <span className="hidden sm:inline">
+            {dryRun ? "Dry Run" : "LIVE"}
+          </span>
         </button>
 
         {/* Scan button */}
         <button
           onClick={startScan}
-          disabled={!selectedProfile || scanStatus === 'scanning'}
+          disabled={!selectedProfile || scanStatus === "scanning"}
           className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
           <Scan size={16} />
-          <span className="hidden sm:inline">{scanStatus === 'scanning' ? 'Scanning...' : 'Scan Account'}</span>
+          <span className="hidden sm:inline">
+            {scanStatus === "scanning" ? "Scanning..." : "Scan Account"}
+          </span>
           <span className="sm:hidden">Scan</span>
         </button>
       </div>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -62,19 +62,22 @@ export function Header() {
     <header className="h-14 bg-bg-secondary border-b border-border flex items-center justify-between px-3 sm:px-4 md:px-6 fixed top-0 left-0 md:left-56 right-0 z-10">
       <div className="flex items-center gap-2 sm:gap-4 min-w-0 pl-10 md:pl-0">
         {/* Profile selector */}
-        <div className="relative shrink-0">
-          <select
-            value={selectedProfile ?? ''}
-            onChange={(e) => handleProfileChange(e.target.value)}
-            className="appearance-none bg-bg-tertiary border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-primary focus:outline-none focus:border-accent cursor-pointer max-w-[140px] sm:max-w-none"
-          >
-            {profiles.map((p) => (
-              <option key={p.name} value={p.name}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-          <ChevronDown size={14} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none" />
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-sm text-text-muted hidden lg:inline">AWS Profile:</span>
+          <div className="relative">
+            <select
+              value={selectedProfile ?? ''}
+              onChange={(e) => handleProfileChange(e.target.value)}
+              className="appearance-none bg-bg-tertiary border border-border rounded-lg px-3 py-1.5 pr-8 text-sm text-text-primary focus:outline-none focus:border-accent cursor-pointer max-w-[140px] sm:max-w-none"
+            >
+              {profiles.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <ChevronDown size={14} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none" />
+          </div>
         </div>
 
         {/* Scan progress */}
@@ -99,6 +102,11 @@ export function Header() {
         {/* Dry-run toggle */}
         <button
           onClick={toggleDryRun}
+          title={
+            dryRun
+              ? 'Dry Run: Preview deletions without actually removing resources'
+              : 'LIVE Mode: Deletions will permanently remove AWS resources'
+          }
           className={`flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
             dryRun
               ? 'bg-success/10 text-success border-success/30 hover:bg-success/20'


### PR DESCRIPTION
## Description
  Improves header usability by making the AWS profile dropdown and deletion mode toggle more intuitive for new users.

  ## Changes
  - Added "AWS Profile:" label before the dropdown selector
  - Added hover tooltips to the Dry Run/LIVE toggle button explaining the difference:
    - **Dry Run**: Preview deletions without actually removing resources
    - **LIVE Mode**: Deletions will permanently remove AWS resources

  ## Motivation
  When using CloudVac for the first time, the header dropdown wasn't immediately clear that it was for AWS profiles. The
  Dry Run vs LIVE toggle is a critical safety feature, but new users might not understand the difference without reading
  documentation. These small UI improvements make the interface more self-documenting.

  ## Screenshots
<img width="1912" height="177" alt="Screenshot 2026-02-18 024506" src="https://github.com/user-attachments/assets/9c74a5a8-8434-4a35-8721-c8022e2cc870" />


  ## Checklist
  - [x] Follows existing code style
  - [x] No breaking changes
  - [x] UI-only change, no backend modifications